### PR TITLE
fits.io: fix identify_format IndexError when filepath is non-FITS (swev-id: astropy__astropy-14309)

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -64,12 +64,19 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
         sig = fileobj.read(30)
         fileobj.seek(pos)
         return sig == FITS_SIGNATURE
+
     elif filepath is not None:
         if filepath.lower().endswith(
             (".fits", ".fits.gz", ".fit", ".fit.gz", ".fts", ".fts.gz")
         ):
             return True
-    return isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU))
+    # If no fileobj/filepath match, fall back to type-based identification.
+    # Guard against empty args to avoid IndexError when called from
+    # identify_format with no positional args (e.g., write path given as string
+    # for non-FITS formats like ECSV). See gh-astropy#14309.
+    if args:
+        return isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU))
+    return False
 
 
 def _decode_mixins(tbl):


### PR DESCRIPTION
Fix IndexError in io.registry identify_format when FITS identifier attempts to access args[0] with empty args. Guard args access and return False when no args provided. Adds no new tests here due to restricted CI, but behavior now matches other identifiers (e.g., parquet, votable) which do not assume args is non-empty. Repro case from issue: identify_format("write", Table, "bububu.ecsv", None, [], {}) now returns without error.

This addresses regression introduced by commit 2a0c5c6f5b98 where fallback returned to isinstance(args[0], ...). Now we check if args is present before isinstance.

Notes:
- Does not run CI per instructions.
- Target base branch: astropy__astropy-14309.
- No merge performed.