### PR TITLE
swev-id: astropy__astropy-14182 ascii.rst: support header_rows for multi-row headers

### DIFF
--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -79,7 +79,7 @@ class RST(FixedWidth):
         # identical to the header/body separator. When multiple header rows
         # are present, the separator appears after the last header row. Use
         # the number of header rows to select that rule line.
-        header_rows = getattr(self.header, "header_rows", ["name"])  # fallback
+        header_rows = getattr(self.header, "header_rows", None) or ["name"]
         sep_index = len(header_rows)
         sep_line = lines[sep_index]
         lines = [sep_line] + lines + [sep_line]

--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -57,10 +57,29 @@ class RST(FixedWidth):
     data_class = SimpleRSTData
     header_class = SimpleRSTHeader
 
-    def __init__(self):
-        super().__init__(delimiter_pad=None, bookend=False)
+    def __init__(self, header_rows=None):
+        """Initialize the RST writer.
+
+        Parameters
+        ----------
+        header_rows : list of str or None
+            Optional list of column attributes to include as header rows.
+            Examples: ["name"], ["name", "unit"]. When None, defaults to
+            ["name"].
+        """
+        # Pass through header_rows to FixedWidth to allow multi-row headers.
+        super().__init__(delimiter_pad=None, bookend=False, header_rows=header_rows)
 
     def write(self, lines):
+        # Collect the core lines from FixedWidth writer which include:
+        #   [ header rows..., header/body separator, data rows... ]
         lines = super().write(lines)
-        lines = [lines[1]] + lines + [lines[1]]
+
+        # The simple RST table format requires a top rule and a bottom rule
+        # identical to the header/body separator. When multiple header rows
+        # are present, the separator appears after the last header row, so
+        # its index is equal to the number of header rows.
+        sep_index = len(getattr(self.data, "header_rows", ["name"]))
+        sep_line = lines[sep_index]
+        lines = [sep_line] + lines + [sep_line]
         return lines

--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -77,9 +77,10 @@ class RST(FixedWidth):
 
         # The simple RST table format requires a top rule and a bottom rule
         # identical to the header/body separator. When multiple header rows
-        # are present, the separator appears after the last header row, so
-        # its index is equal to the number of header rows.
-        sep_index = len(getattr(self.data, "header_rows", ["name"]))
+        # are present, the separator appears after the last header row. Use
+        # the number of header rows to select that rule line.
+        header_rows = getattr(self.header, "header_rows", ["name"])  # fallback
+        sep_index = len(header_rows)
         sep_line = lines[sep_index]
         lines = [sep_line] + lines + [sep_line]
         return lines

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -212,3 +212,19 @@ def test_write_with_header_rows_name_unit():
 ===== ========
 """,
     )
+
+
+
+def test_write_default_header_unchanged():
+    """Single-row header remains identical to previous behavior."""
+    tbl = QTable({"wave": [350, 950] * u.nm, "response": [0.7, 1.2] * u.count})
+    out = StringIO()
+    ascii.write(tbl, out, Writer=ascii.RST)
+    expected = """===== ========
+ wave response
+===== ========
+350.0      0.7
+950.0      1.2
+===== ========
+"""
+    assert_equal_splitlines(out.getvalue(), expected)

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
+
 from io import StringIO
 
+import astropy.units as u
+from astropy.table import QTable
 from astropy.io import ascii
 
 from .common import assert_almost_equal, assert_equal
@@ -183,5 +187,28 @@ Col1      Col2 Col3 Col4
  1.2   "hello"    1    a
  2.4 's worlds    2    2
 ==== ========= ==== ====
+""",
+    )
+
+
+
+def test_write_with_header_rows_name_unit():
+    """Write a SimpleRST table with multiple header rows (name, unit)."""
+    tbl = QTable({"wave": [350, 950] * u.nm, "response": [0.7, 1.2] * u.count})
+    out = StringIO()
+    ascii.write(tbl, out, Writer=ascii.RST, header_rows=["name", "unit"])
+    # Column widths are computed across header and data rows:
+    # wave column width = max(len('wave'), len('nm'), len('350.0'), len('950.0')) = 5
+    # response column width = max(len('response'), len('ct'), len('0.7'), len('1.2')) = 8
+    # Thus, the rule lines have 5 and 8 '=' characters respectively.
+    assert_equal_splitlines(
+        out.getvalue(),
+        """===== ========
+ wave response
+   nm       ct
+===== ========
+350.0      0.7
+950.0      1.2
+===== ========
 """,
     )


### PR DESCRIPTION
This PR enables header_rows in the ascii.rst writer so that multi-line headers (e.g., name + unit) are supported, analogous to other fixed-width writers.\n\nKey changes\n- RST.__init__ now accepts header_rows and passes it through to FixedWidth.\n- RST.write now determines the rule line from the number of header rows and bookends the table with that rule.\n\nBehavior\n- Default remains unchanged for single header row.\n- With header_rows=["name", "unit"], the output matches simple RST table format: top rule, the two header rows, header/body rule, data rows, bottom rule.\n\nTests\n- Added a test to verify the multi-row header output for name+unit.\n\nCloses #13