### PR TITLE
swev-id: astropy__astropy-14365 - ascii.qdp: accept case-insensitive QDP directive commands

### DIFF
--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -60,7 +60,11 @@ def _line_type(line, delimiter=None):
     ValueError: Unrecognized QDP line...
     """
     _decimal_re = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
-    _command_re = r"READ [TS]ERR(\s+[0-9]+)+"
+    # Make directive command detection case-insensitive so that lines like
+    # "read serr 1 2" or mixed-case variants are recognized.
+    # Use an inline case-insensitive flag scoped to the command pattern
+    # to avoid affecting other parts of the regex (e.g., data and NO tokens).
+    _command_re = r"(?i:READ [TS]ERR(\s+[0-9]+)+)"
 
     sep = delimiter
     if delimiter is None:

--- a/astropy/io/ascii/tests/test_qdp.py
+++ b/astropy/io/ascii/tests/test_qdp.py
@@ -245,3 +245,46 @@ def test_get_lines_from_qdp(tmp_path):
         assert file_output[i] == line
         assert list_output[i] == line
         assert text_output[i] == line
+
+
+def test_lowercase_read_serr_simple():
+    import io
+    from astropy.table import Table
+
+    content = "read serr 1 2
+1 0.5 1 0.5
+"
+    t = Table.read(io.StringIO(content), format="ascii.qdp")
+    assert t.colnames == ["col1", "col1_err", "col2", "col2_err"]
+    assert len(t) == 1
+    assert t["col1"][0] == 1
+    assert t["col1_err"][0] == 0.5
+    assert t["col2"][0] == 1
+    assert t["col2_err"][0] == 0.5
+
+
+def test_mixed_case_read_terr_simple():
+    import io
+    from astropy.table import Table
+
+    content = "ReAd TeRr 1
+1 0.1 -0.2
+"
+    t = Table.read(io.StringIO(content), format="ascii.qdp")
+    assert t.colnames == ["col1", "col1_perr", "col1_nerr"]
+    assert len(t) == 1
+    assert t["col1"][0] == 1
+    assert t["col1_perr"][0] == 0.1
+    assert t["col1_nerr"][0] == -0.2
+
+
+def test_unrecognized_directive_still_errors():
+    import io
+    import pytest
+    from astropy.table import Table
+
+    content = "read xyz 1 2
+1 2
+"
+    with pytest.raises(ValueError):
+        Table.read(io.StringIO(content), format="ascii.qdp")


### PR DESCRIPTION
This PR makes the ascii.qdp reader accept QDP directive commands in any case (uppercase/lowercase/mixed).

Changes
- Case-insensitive directive detection in astropy/io/ascii/qdp.py via inline (?i) scoped to the command pattern.
- Tests added for lowercase READ SERR and mixed-case READ TERR.
- Error behavior for unrecognized directives is unchanged.

Why
QDP is case-insensitive, but current reader expected uppercase commands only. This fixes crashes like:

```
read serr 1 2
1 0.5 1 0.5
```

Closes #24.

Notes
- Target branch: astropy__astropy-14365.
- CI should not be manually triggered.
- Not merging per request.