### PR TITLE
swev-id: astropy__astropy-7336 Fix: quantity_input skips conversion for None return annotations (constructors)

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -220,8 +220,10 @@ class QuantityInput:
             # Call the original function with any equivalencies in force.
             with add_enabled_equivalencies(self.equivalencies):
                 return_ = wrapped_function(*func_args, **func_kwargs)
-            if wrapped_signature.return_annotation is not inspect.Signature.empty:
-                return return_.to(wrapped_signature.return_annotation)
+            # If a return annotation is present and not None, attempt conversion
+            anno = wrapped_signature.return_annotation
+            if anno is not inspect.Signature.empty and anno is not None:
+                return return_.to(anno)
             else:
                 return return_
 

--- a/astropy/units/tests/test_quantity_input_return_none.py
+++ b/astropy/units/tests/test_quantity_input_return_none.py
@@ -1,0 +1,39 @@
+import pytest
+import astropy.units as u
+
+
+class Device:
+    @u.quantity_input
+    def __init__(self, voltage: u.V) -> None:
+        self.voltage = voltage
+
+
+def test_constructor_with_valid_unit():
+    d = Device(5 * u.V)
+    assert d.voltage == 5 * u.V
+
+
+def test_constructor_with_invalid_unit():
+    with pytest.raises(u.UnitsError):
+        Device(5 * u.s)
+
+
+@u.quantity_input
+def f(x: u.m) -> None:
+    pass
+
+
+def test_function_return_none_valid_arg():
+    # Should not raise for correct units
+    f(1 * u.m)
+
+
+@u.quantity_input
+def g() -> u.dimensionless_unscaled:
+    return 2 * u.m / (2 * u.m)
+
+
+def test_dimensionless_return():
+    q = g()
+    assert q.unit is u.dimensionless_unscaled
+    assert q.value == 1


### PR DESCRIPTION
Summary
The astropy.units.quantity_input decorator fails when decorating functions/methods/constructors that have a type-hinted return value -> None. Specifically, it attempts to call .to() on the return annotation, resulting in AttributeError: 'NoneType' object has no attribute 'to'.

Reproducer
```
import astropy.units as u

class PoC(object):
    @u.quantity_input
    def __init__(self, voltage: u.V) -> None:
        pass

p = PoC(1. * u.V)
```
Error:
```
AttributeError: 'NoneType' object has no attribute 'to'
```

Root cause
- File: astropy/units/decorators.py
- Class: QuantityInput
- Method: __call__ → wrapper
- The code does:
  ```
  if wrapped_signature.return_annotation is not inspect.Signature.empty:
      return return_.to(wrapped_signature.return_annotation)
  else:
      return return_
  ```
- When the return annotation is explicitly None (e.g., constructors), .to(None) is attempted and fails.

Proposed fix (minimal and safe)
- In astropy/units/decorators.py, guard against None:
  ```
  anno = wrapped_signature.return_annotation
  if anno is not inspect.Signature.empty and anno is not None:
      return return_.to(anno)
  else:
      return return_
  ```
- This preserves behavior for unit/dimensionless annotations and skips conversion for None.

Tests to add
- Under astropy/units/tests, new test module (e.g., test_quantity_input_return_none.py):
  - Constructor annotated -> None:
    - class Device with @u.quantity_input on __init__(voltage: u.V) -> None; Device(5*u.V) succeeds; Device(5*u.s) raises u.UnitsError.
  - Regular function annotated -> None:
    - @u.quantity_input def f(x: u.m) -> None: pass; call f(1*u.m) should not raise.
  - Regression guard for dimensionless return:
    - @u.quantity_input def g() -> u.dimensionless_unscaled: return 2*u.m/(2*u.m); g() returns Quantity with unit u.dimensionless_unscaled and value 1.

Acceptance criteria
- No AttributeError when using @u.quantity_input on functions/methods/constructors annotated with -> None.
- New tests pass locally; existing quantity_input tests continue to pass.

Notes
- Do not run CI for this PR per task instructions; include [ci skip] in commit messages to prevent CI.
- Optional: add a CHANGES.rst entry under astropy.units noting the bugfix.
