### PR TITLE
TimeSeries: clarify required columns error messages (swev-id: astropy__astropy-13033)

### DIFF
--- a/astropy/timeseries/core.py
+++ b/astropy/timeseries/core.py
@@ -67,18 +67,46 @@ class BaseTimeSeries(QTable):
                 required_columns = self._required_columns
 
             plural = 's' if len(required_columns) > 1 else ''
+            required_count = len(required_columns)
 
             if not self._required_columns_relax and len(self.colnames) == 0:
 
-                raise ValueError("{} object is invalid - expected '{}' "
-                                 "as the first column{} but time series has no columns"
-                                 .format(self.__class__.__name__, required_columns[0], plural))
+                if required_count == 1:
+                    raise ValueError("{} object is invalid - expected '{}' "
+                                     "as the first column{} but time series has no columns"
+                                     .format(self.__class__.__name__, required_columns[0], plural))
 
-            elif self.colnames[:len(required_columns)] != required_columns:
+                raise ValueError(
+                    "{} object is invalid - required {!r} as the first columns "
+                    "but time series has no columns".format(
+                        self.__class__.__name__,
+                        required_columns,
+                    )
+                )
 
-                raise ValueError("{} object is invalid - expected '{}' "
-                                 "as the first column{} but found '{}'"
-                                 .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
+            actual_prefix = self.colnames[:required_count]
+
+            if actual_prefix != required_columns:
+
+                if required_count == 1:
+                    raise ValueError(
+                        "{} object is invalid - expected '{}' "
+                        "as the first column{} but found '{}'".format(
+                            self.__class__.__name__,
+                            required_columns[0],
+                            plural,
+                            self.colnames[0],
+                        )
+                    )
+
+                raise ValueError(
+                    "{} object is invalid - required {!r} as the first columns "
+                    "but found {!r}".format(
+                        self.__class__.__name__,
+                        required_columns,
+                        actual_prefix,
+                    )
+                )
 
             if (self._required_columns_relax
                     and self._required_columns == self.colnames[:len(self._required_columns)]):

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -38,6 +38,22 @@ def test_empty_initialization_invalid():
                                  "'time' as the first column but found 'flux'")
 
 
+def test_required_columns_missing_non_time_required():
+    ts = TimeSeries(time=INPUT_TIME)
+    ts['a'] = [1, 2, 3]
+
+    ts._required_columns = ['time', 'flux']
+    ts.add_column([1, 2, 3], name='flux', index=1)
+
+    with pytest.raises(ValueError) as exc:
+        ts.remove_column('flux')
+
+    assert str(exc.value) == (
+        "TimeSeries object is invalid - required ['time', 'flux'] as the first "
+        "columns but found ['time', 'a']"
+    )
+
+
 def test_initialize_only_time():
     ts = TimeSeries(time=INPUT_TIME)
     assert ts['time'] is ts.time
@@ -304,7 +320,10 @@ def test_pandas():
 def test_read_time_missing():
     with pytest.raises(ValueError) as exc:
         TimeSeries.read(CSV_FILE, format='csv')
-    assert exc.value.args[0] == '``time_column`` should be provided since the default Table readers are being used.'
+    assert exc.value.args[0] == (
+        '``time_column`` should be provided since the default Table readers are '
+        'being used.'
+    )
 
 
 def test_read_time_wrong():
@@ -339,7 +358,9 @@ def test_kepler_astropy():
 
 @pytest.mark.remote_data(source='astropy')
 def test_tess_astropy():
-    filename = get_pkg_data_filename('timeseries/hlsp_tess-data-alerts_tess_phot_00025155310-s01_tess_v1_lc.fits')
+    filename = get_pkg_data_filename(
+        'timeseries/hlsp_tess-data-alerts_tess_phot_00025155310-s01_tess_v1_lc.fits'
+    )
     with pytest.warns(UserWarning, match='Ignoring 815 rows with NaN times'):
         timeseries = TimeSeries.read(filename, format='tess.fits')
     assert timeseries["time"].format == 'isot'


### PR DESCRIPTION
## Summary
- refine `BaseTimeSeries._check_required_columns` to emit list-style errors when multi-column requirements are violated
- add regression coverage using `TimeSeries` to assert the clearer message for missing secondary required columns
- ensure single-column validations retain their previous messaging

## Reproduction Steps
1. Create a `TimeSeries` and set `ts._required_columns = ['time', 'flux']`
2. Insert a `flux` column at index 1, then remove it so the table starts `['time', 'a']`
3. Trigger the automatic check via `ts.remove_column('flux')`

### Observed Failure (before this change)
```
ValueError: TimeSeries object is invalid - expected 'time' as the first column but found 'time'
```

### New Behavior
- Multi-column requirements now raise
  - `... required ['time', 'flux'] as the first columns but time series has no columns`, or
  - `... required ['time', 'flux'] as the first columns but found ['time', 'a']`
- Single-column error messages are unchanged

Fixes #65

## Testing
- `LD_LIBRARY_PATH=$HOME/.nix-profile/lib .venv/bin/pytest tmp_test_required_columns.py`
