### PR TITLE
fix: separability for nested CompoundModels (swev-id: astropy__astropy-12907)

### DIFF
--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -242,7 +242,7 @@ def _cstack(left, right):
         cright = _coord_matrix(right, 'right', noutp)
     else:
         cright = np.zeros((noutp, right.shape[1]))
-        cright[-right.shape[0]:, -right.shape[1]:] = 1
+        cright[-right.shape[0]:, -right.shape[1]:] = right
 
     return np.hstack([cleft, cright])
 

--- a/astropy/modeling/tests/test_separable_regressions.py
+++ b/astropy/modeling/tests/test_separable_regressions.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Regression tests for separability matrix combinations."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from astropy.modeling import models
+from astropy.modeling.separable import separability_matrix
+
+
+def test_separability_plain_and():
+    compound = models.Linear1D(10) & models.Linear1D(5)
+    expected = np.array([[True, False], [False, True]])
+    assert np.array_equal(separability_matrix(compound), expected)
+
+
+def test_separability_mixed_compound():
+    compound = models.Identity(2) & models.Linear1D(10) & models.Linear1D(5)
+    expected = np.eye(4, dtype=bool)
+    assert np.array_equal(separability_matrix(compound), expected)
+
+
+def test_separability_nested_compound():
+    inner = models.Identity(2)
+    compound = models.Identity(2) & inner
+    expected = np.eye(4, dtype=bool)
+    assert np.array_equal(separability_matrix(compound), expected)
+
+
+def test_separability_deep_nesting_equivalence():
+    a = models.Linear1D(1)
+    b = models.Linear1D(2)
+    c = models.Linear1D(3)
+    d = models.Linear1D(4)
+    nested = (a & (b & c)) & d
+    flat = a & b & c & d
+    assert np.array_equal(separability_matrix(nested), separability_matrix(flat))


### PR DESCRIPTION
### Description
- add regression coverage for CompoundModel nesting
- fix `_cstack` to concatenate right coord matrices without dropping structure
- commits include `[skip ci]` per instructions to avoid running CI

### Reproduction Steps
1. Plain conjunction (matches expectation):
   ```python
   from astropy.modeling import models
   from astropy.modeling.separable import separability_matrix

   compound = models.Linear1D(10) & models.Linear1D(5)
   print(separability_matrix(compound))
   # expected / observed
   # [[ True False]
   #  [False  True]]
   ```
2. Mixed compound (non-nested) remains correct:
   ```python
   compound = models.Pix2Sky_TAN() & models.Linear1D(10) & models.Linear1D(5)
   print(separability_matrix(compound))
   # expected / observed
   # [[ True  True False False]
   #  [ True  True False False]
   #  [False False  True False]
   #  [False False False  True]]
   ```
3. Nested compound (pre-fix observed incorrect duplication):
   ```python
   inner = models.Linear1D(10) & models.Linear1D(5)
   compound = models.Pix2Sky_TAN() & inner
   print(separability_matrix(compound))
   # expected
   # [[ True  True False False]
   #  [ True  True False False]
   #  [False False  True False]
   #  [False False False  True]]
   # observed (before fix)
   # [[ True  True False False]
   #  [ True  True False False]
   #  [False False  True  True]
   #  [False False  True  True]]
   ```

### Failing Pytest Trace (pre-fix)
```
______________________ test_separability_nested_compound _______________________

    def test_separability_nested_compound():
        inner = models.Identity(2)
        compound = models.Identity(2) & inner
        expected = np.eye(4, dtype=bool)
>       assert np.array_equal(separability_matrix(compound), expected)
E       assert False
E        +  where False = <function array_equal at 0xffff98d088b0>(array([[ True, False, False, False],
E       [False,  True, False, False],
E       [False, False,  True,  True],
E       [False, False,  True,  True]]), array([[ True, False, False, False],
E       [False,  True, False, False],
E       [False, False,  True, False],
E       [False, False, False,  True]]))
E        +    where <function array_equal at 0xffff98d088b0> = np.array_equal
E        +    and   array([[ True, False, False, False],
E       [False,  True, False, False],
E       [False, False,  True,  True],
E       [False, False,  True,  True]]) = separability_matrix(<CompoundModel()>)

../modeling/tests/test_separable_regressions.py:28: AssertionError
```

Fixes #66
