### PR TITLE
swev-id: astropy__astropy-14995 Fix NDDataRef mask propagation when other operand has no mask

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -513,18 +513,24 @@ class NDArithmeticMixin:
             ``handle_mask`` must create (and copy) the returned mask.
         """
         # If only one mask is present we need not bother about any type checks
-        if (
-            self.mask is None and operand is not None and operand.mask is None
-        ) or handle_mask is None:
+        if handle_mask is None:
             return None
-        elif self.mask is None and operand is not None:
-            # Make a copy so there is no reference in the result.
-            return deepcopy(operand.mask)
-        elif operand is None:
+
+        if operand is None:
             return deepcopy(self.mask)
-        else:
-            # Now lets calculate the resulting mask (operation enforces copy)
-            return handle_mask(self.mask, operand.mask, **kwds)
+
+        operand_mask = operand.mask
+
+        if self.mask is None and operand_mask is None:
+            return None
+        if self.mask is None:
+            # Make a copy so there is no reference in the result.
+            return deepcopy(operand_mask)
+        if operand_mask is None:
+            return deepcopy(self.mask)
+
+        # Now lets calculate the resulting mask (operation enforces copy)
+        return handle_mask(self.mask, operand_mask, **kwds)
 
     def _arithmetic_wcs(self, operation, operand, compare_wcs, **kwds):
         """

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1383,4 +1383,3 @@ def test_raise_method_not_supported():
     # raise error for unsupported propagation operations:
     with pytest.raises(ValueError):
         ndd1.uncertainty.propagate(np.mod, ndd2, result, correlation)
-# CI trigger: no-op change

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -314,6 +314,79 @@ def test_arithmetics_data_masks_invalid():
         nd1.divide(nd2)
 
 
+@pytest.mark.parametrize(
+    "mask",
+    [
+        np.array([[True, False], [False, True]], dtype=np.bool_),
+        np.array([[1, 0], [0, 1]], dtype=np.uint8),
+    ],
+)
+@pytest.mark.parametrize("handle_mask", [np.bitwise_or, np.logical_or])
+def test_arithmetics_single_mask_scalar(handle_mask, mask):
+    nd = NDDataArithmetic(np.ones_like(mask, dtype=float), mask=mask)
+
+    result = nd.multiply(1.0, handle_mask=handle_mask)
+
+    assert_array_equal(mask, result.mask)
+    assert result.mask.dtype == mask.dtype
+    assert not np.may_share_memory(result.mask, mask)
+
+
+def test_arithmetics_single_mask_nddataref_commutativity_bitwise_or():
+    mask = np.array([[True, False], [False, True]], dtype=np.bool_)
+    data = np.arange(4).reshape(2, 2)
+    masked = NDDataArithmetic(data, mask=mask)
+    unmasked = NDDataArithmetic(data)
+
+    forward = masked.multiply(unmasked, handle_mask=np.bitwise_or)
+    reverse = unmasked.multiply(masked, handle_mask=np.bitwise_or)
+
+    assert_array_equal(mask, forward.mask)
+    assert_array_equal(mask, reverse.mask)
+    assert forward.mask.dtype == mask.dtype
+    assert reverse.mask.dtype == mask.dtype
+    assert_array_equal(forward.mask, reverse.mask)
+    assert not np.may_share_memory(forward.mask, mask)
+    assert not np.may_share_memory(reverse.mask, mask)
+
+
+@pytest.mark.parametrize("handle_mask", [np.bitwise_or, np.logical_or])
+def test_arithmetics_both_masked(handle_mask):
+    mask1 = np.array([[True, False], [False, True]], dtype=np.bool_)
+    mask2 = np.array([[False, True], [True, False]], dtype=np.bool_)
+
+    nd1 = NDDataArithmetic(np.ones((2, 2)), mask=mask1)
+    nd2 = NDDataArithmetic(np.ones((2, 2)), mask=mask2)
+
+    result = nd1.add(nd2, handle_mask=handle_mask)
+
+    expected = handle_mask(mask1, mask2)
+    assert_array_equal(expected, result.mask)
+    assert np.issubdtype(result.mask.dtype, np.bool_)
+
+
+@pytest.mark.parametrize("handle_mask", [np.bitwise_or, np.logical_or])
+def test_arithmetics_no_masks(handle_mask):
+    nd1 = NDDataArithmetic(np.ones((2, 2)))
+    nd2 = NDDataArithmetic(np.ones((2, 2)))
+
+    result = nd1.add(nd2, handle_mask=handle_mask)
+
+    assert result.mask is None
+
+
+def test_arithmetics_mask_preserved_with_array_operand():
+    mask = np.array([True, False, True, False], dtype=np.bool_)
+    data = np.arange(mask.size)
+
+    nd = NDDataArithmetic(data, mask=mask)
+    result = nd.add(np.ones_like(data), handle_mask=np.bitwise_or)
+
+    assert_array_equal(mask, result.mask)
+    assert result.mask.dtype == mask.dtype
+    assert not np.may_share_memory(result.mask, mask)
+
+
 # Covering:
 # both have uncertainties (data and uncertainty without unit)
 # tested against manually determined resulting uncertainties to verify the

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1383,3 +1383,4 @@ def test_raise_method_not_supported():
     # raise error for unsupported propagation operations:
     with pytest.raises(ValueError):
         ndd1.uncertainty.propagate(np.mod, ndd2, result, correlation)
+# CI trigger: no-op change


### PR DESCRIPTION
## Issue
- Closes #82

## Reproduction
1. In a clean checkout of `astropy__astropy-14995`, launch Python and run
   ```python
   import numpy as np
   from astropy.nddata import NDDataRef

   mask = np.array([[True, False], [False, True]])
   data = np.array([[1, 2], [3, 4]])
   NDDataRef(data=data, mask=mask).multiply(1.0, handle_mask=np.bitwise_or)
   ```
2. Swap operand order to exercise commutativity:
   ```python
   import numpy as np
   from astropy.nddata import NDDataRef

   mask = np.array([[True, False], [False, True]])
   data = np.array([[1, 2], [3, 4]])
   masked = NDDataRef(data=data, mask=mask)
   unmasked = NDDataRef(data=data)
   masked.multiply(unmasked, handle_mask=np.bitwise_or)
   ```

## Observed failure
### Scalar operand with `np.bitwise_or`
```
/workspace/astropy/astropy/version.py:12: UserWarning: could not determine astropy package version; this indicates a broken installation
  warnings.warn(
Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 618, in multiply
    return self._prepare_then_do_arithmetic(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 731, in _prepare_then_do_arithmetic
    result, init_kwds = operand._arithmetic(operation, operand2, **kwargs)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 335, in _arithmetic
    kwargs["mask"] = self._arithmetic_mask(
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 527, in _arithmetic_mask
    return handle_mask(self.mask, operand.mask, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for |: 'bool' and 'NoneType'
```

### NDDataRef commutativity with `np.bitwise_or`
```
/workspace/astropy/astropy/version.py:12: UserWarning: could not determine astropy package version; this indicates a broken installation
  warnings.warn(
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 618, in multiply
    return self._prepare_then_do_arithmetic(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 734, in _prepare_then_do_arithmetic
    result, init_kwds = cls._arithmetic(
                        ^^^^^^^^^^^^^^^^
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 335, in _arithmetic
    kwargs["mask"] = self._arithmetic_mask(
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/astropy/astropy/nddata/mixins/ndarithmetic.py", line 527, in _arithmetic_mask
    return handle_mask(self.mask, operand.mask, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for |: 'bool' and 'NoneType'
```

## Fix
- Guard `_arithmetic_mask` against `operand is None` and capture the operand's mask before accessing it.
- Return deep copies of whichever mask is present when the other operand lacks a mask so mask handlers never receive `None` inputs.
- Preserve the existing handler path for the both-masked case.

## Tests
- Added regression tests covering scalar operands, NDDataRef commutativity, dual-mask combination, mask-less operands, and numpy array operands with both `np.bitwise_or` and `np.logical_or` handlers.
- `pytest astropy/nddata/mixins/tests/test_ndarithmetic.py -q`
- `tox -e codestyle -- --files astropy/nddata/mixins/ndarithmetic.py astropy/nddata/mixins/tests/test_ndarithmetic.py`