### PR TITLE
Fix long string doubled quote parsing

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -859,9 +859,29 @@ class Card(_Verify):
                     return kw, vc
 
                 value = m.group("strg") or ""
-                value = value.rstrip().replace("''", "'")
+                trailing = vc[m.end("strg") : m.end(0)]
+                if trailing:
+                    trailing_spaces = trailing.replace("'", "")
+                    if trailing_spaces:
+                        space_len = len(trailing_spaces) - len(trailing_spaces.lstrip(" "))
+                        if space_len > 0:
+                            value += trailing_spaces[:space_len]
+                remainder = vc[m.end(0) :]
                 if value and value[-1] == "&":
                     value = value[:-1]
+                if remainder:
+                    remainder = remainder.rstrip()
+                    if remainder and not remainder.startswith("/"):
+                        # Handle value fragments that were not consumed by the
+                        # regex match (e.g. text following doubled quotes
+                        # before the continuation marker) by appending them to
+                        # the accumulated value.
+                        extra_value = remainder
+                        if "/" in extra_value:
+                            extra_value = extra_value.split("/", 1)[0]
+                        if "&" in extra_value:
+                            extra_value = extra_value.split("&", 1)[0]
+                        value += extra_value
                 values.append(value)
                 comment = m.group("comm")
                 if comment:
@@ -870,8 +890,13 @@ class Card(_Verify):
             if keyword in self._commentary_keywords:
                 valuecomment = "".join(values)
             else:
-                # CONTINUE card
-                valuecomment = f"'{''.join(values)}' / {' '.join(comments)}"
+                joined = "".join(values)
+                actual_value = joined.replace("''", "'")
+                encoded_value = _format_value(actual_value).strip()
+                if comments:
+                    valuecomment = f"{encoded_value} / {' '.join(comments)}"
+                else:
+                    valuecomment = encoded_value
             return keyword, valuecomment
 
         if self.keyword in self._special_keywords:

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -468,6 +468,69 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'xml'                                                                 "
         )
 
+    @pytest.mark.parametrize("comment", [None, "comment"])
+    def test_long_string_trailing_doubled_quotes_round_trip(self, comment):
+        for n in range(60, 100):
+            value = "x" * n + "''"
+            if comment is None:
+                card = fits.Card("CONFIG", value)
+                image = card.image
+            else:
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always", VerifyWarning)
+                    card = fits.Card("CONFIG", value, comment)
+                    image = card.image
+                emitted_warning = any(
+                    isinstance(w.message, VerifyWarning) for w in caught
+                )
+                if len(image) == card.length:
+                    assert emitted_warning
+                else:
+                    assert not emitted_warning
+            round_trip = fits.Card.fromstring(image)
+            assert round_trip.value == value
+            if comment is None:
+                assert round_trip.comment == ""
+            else:
+                if len(card.image) > card.length:
+                    assert round_trip.comment == comment
+                else:
+                    parts = card.image.split("/", 1)
+                    expected_comment = parts[1].strip() if len(parts) == 2 else ""
+                    assert round_trip.comment == expected_comment
+
+    def test_long_string_embedded_doubled_quotes_across_boundaries(self):
+        prefix = "A" * 48
+        suffix = "B" * 64
+        value = prefix + "''" + suffix
+        card = fits.Card("BOUND", value, "spans boundaries")
+        round_trip = fits.Card.fromstring(card.image)
+        assert round_trip.value == value
+        assert round_trip.comment == "spans boundaries"
+
+    @pytest.mark.parametrize(
+        "value, comment",
+        [
+            ("x" * 100 + "''", "comment"),
+            ("x" * 100 + "'' aaa", "comment"),
+        ],
+    )
+    def test_long_string_regression_cases_with_trailing_quotes(self, value, comment):
+        card = fits.Card("FOO", value, comment)
+        round_trip = fits.Card.fromstring(card.image)
+        assert round_trip.value == value
+        assert round_trip.comment == comment
+
+    def test_null_string_round_trip_including_continued_value(self):
+        card = fits.Card("NULL", "''")
+        round_trip = fits.Card.fromstring(card.image)
+        assert round_trip.value == "''"
+
+        long_value = "prefix-" + "y" * 48 + "''" + "z" * 48 + "-suffix"
+        long_card = fits.Card("NULL", long_value)
+        long_round_trip = fits.Card.fromstring(long_card.image)
+        assert long_round_trip.value == long_value
+
     def test_long_unicode_string(self):
         """Regression test for
         https://github.com/spacetelescope/PyFITS/issues/1


### PR DESCRIPTION
## Summary
- retain trailing doubled quotes when splitting CONTINUE segments
- rebuild long string value using full decoded text before re-encoding
- add regression coverage for doubled quote continuations and null strings

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:  python -m pytest -p pytest_astropy_header -p pytest_doctestplus   /workspace/astropy/.venv/lib/python3.11/site-packages/astropy/io/fits/tests/test_header.py   -k "doubled_quotes or regression_cases_with_trailing_quotes or null_string_round_trip_including_continued_value"

Fixes #71