### PR TITLE
Fix: UnrecognizedUnit __eq__ with None returns False (no TypeError) [swev-id: astropy__astropy-7606]

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1710,8 +1710,12 @@ class UnrecognizedUnit(IrreducibleUnit):
         _unrecognized_operator
 
     def __eq__(self, other):
-        other = Unit(other, parse_strict='silent')
-        return isinstance(other, UnrecognizedUnit) and self.name == other.name
+        try:
+            other_unit = Unit(other, parse_strict='silent')
+        except (ValueError, UnitsError, TypeError):
+            return False
+        return (isinstance(other_unit, UnrecognizedUnit) and
+                self.name == other_unit.name)
 
     def __ne__(self, other):
         return not (self == other)

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -198,6 +198,23 @@ def test_unknown_unit3():
         unit5 = u.Unit(None)
 
 
+def test_unrecognized_compare_with_none():
+    x = u.Unit('asdf', parse_strict='silent')
+    assert not (x == None)  # noqa: E711
+    assert x != None  # noqa: E711
+
+
+def test_unrecognized_equality_with_string():
+    x = u.Unit('asdf', parse_strict='silent')
+    assert x == 'asdf'
+    assert x != 'qwer'
+
+
+def test_unrecognized_compare_with_non_unit_types():
+    x = u.Unit('asdf', parse_strict='silent')
+    assert not (x == object())
+
+
 @raises(TypeError)
 def test_invalid_scale():
     x = ['a', 'b', 'c'] * u.m


### PR DESCRIPTION
## Observed failure
```
In [12]: x = u.Unit('asdf', parse_strict='silent')

In [13]: x == None  # Should be False
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-13-2486f2ccf928> in <module>()
----> 1 x == None  # Should be False

/Users/aldcroft/anaconda3/lib/python3.5/site-packages/astropy/units/core.py in __eq__(self, other)
   1699 
   1700     def __eq__(self, other):
-> 1701         other = Unit(other, parse_strict='silent')
   1702         return isinstance(other, UnrecognizedUnit) and self.name == other.name
   1703 

/Users/aldcroft/anaconda3/lib/python3.5/site-packages/astropy/units/core.py in __call__(self, s, represents, format, namespace, doc, parse_strict)
   1808 
   1809         elif s is None:
-> 1810             raise TypeError("None is not a valid Unit")
   1811 
   1812         else:

TypeError: None is not a valid Unit
```

## Fix summary
- guard the Unit(...) conversion inside `UnrecognizedUnit.__eq__` with a `try/except (ValueError, UnitsError, TypeError)` and return `False` on failure
- keep existing equality semantics otherwise and add regression tests for comparisons against `None`, strings, and arbitrary objects

## Testing
- `PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/y26slwav2ygi7gls9dzabygpaipwwwj4-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/python -m pytest astropy/units/tests/test_units.py -k unrecognized --cache-dir=/workspace/.pytest_cache`
- `flake8 astropy/units/core.py astropy/units/tests/test_units.py --per-file-ignores='astropy/units/tests/test_units.py:F841,E501,E222,E711'` (existing style violations in legacy sections; new assertions pass)