### PR TITLE
Fix long string doubled quote parsing — swev-id: astropy__astropy-14598

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -858,32 +858,29 @@ class Card(_Verify):
                 if not m:
                     return kw, vc
 
+                comment = m.group("comm")
                 value = m.group("strg") or ""
-                trailing = vc[m.end("strg") : m.end(0)]
-                if trailing:
-                    trailing_spaces = trailing.replace("'", "")
-                    if trailing_spaces:
-                        space_len = len(trailing_spaces) - len(trailing_spaces.lstrip(" "))
-                        if space_len > 0:
-                            value += trailing_spaces[:space_len]
-                remainder = vc[m.end(0) :]
-                if value and value[-1] == "&":
+                if value.endswith("&"):
                     value = value[:-1]
-                if remainder:
-                    remainder = remainder.rstrip()
-                    if remainder and not remainder.startswith("/"):
-                        # Handle value fragments that were not consumed by the
-                        # regex match (e.g. text following doubled quotes
-                        # before the continuation marker) by appending them to
-                        # the accumulated value.
-                        extra_value = remainder
-                        if "/" in extra_value:
-                            extra_value = extra_value.split("/", 1)[0]
-                        if "&" in extra_value:
-                            extra_value = extra_value.split("&", 1)[0]
+
+                if not comment:
+                    trailing = vc[m.end("strg") : m.end(0)]
+                    if trailing:
+                        trailing_spaces = trailing.replace("'", "")
+                        if trailing_spaces:
+                            value += trailing_spaces
+
+                remainder = vc[m.end(0) :]
+                if remainder and not comment:
+                    extra_value = remainder.rstrip()
+                    if extra_value.endswith("'"):
+                        extra_value = extra_value[:-1]
+                        extra_value = extra_value.rstrip()
+                    if extra_value.endswith("&"):
+                        extra_value = extra_value[:-1]
+                    if extra_value:
                         value += extra_value
                 values.append(value)
-                comment = m.group("comm")
                 if comment:
                     comments.append(comment.rstrip())
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -859,9 +859,29 @@ class Card(_Verify):
                     return kw, vc
 
                 value = m.group("strg") or ""
-                value = value.rstrip().replace("''", "'")
+                trailing = vc[m.end("strg") : m.end(0)]
+                if trailing:
+                    trailing_spaces = trailing.replace("'", "")
+                    if trailing_spaces:
+                        space_len = len(trailing_spaces) - len(trailing_spaces.lstrip(" "))
+                        if space_len > 0:
+                            value += trailing_spaces[:space_len]
+                remainder = vc[m.end(0) :]
                 if value and value[-1] == "&":
                     value = value[:-1]
+                if remainder:
+                    remainder = remainder.rstrip()
+                    if remainder and not remainder.startswith("/"):
+                        # Handle value fragments that were not consumed by the
+                        # regex match (e.g. text following doubled quotes
+                        # before the continuation marker) by appending them to
+                        # the accumulated value.
+                        extra_value = remainder
+                        if "/" in extra_value:
+                            extra_value = extra_value.split("/", 1)[0]
+                        if "&" in extra_value:
+                            extra_value = extra_value.split("&", 1)[0]
+                        value += extra_value
                 values.append(value)
                 comment = m.group("comm")
                 if comment:
@@ -870,8 +890,13 @@ class Card(_Verify):
             if keyword in self._commentary_keywords:
                 valuecomment = "".join(values)
             else:
-                # CONTINUE card
-                valuecomment = f"'{''.join(values)}' / {' '.join(comments)}"
+                joined = "".join(values)
+                actual_value = joined.replace("''", "'")
+                encoded_value = _format_value(actual_value).strip()
+                if comments:
+                    valuecomment = f"{encoded_value} / {' '.join(comments)}"
+                else:
+                    valuecomment = encoded_value
             return keyword, valuecomment
 
         if self.keyword in self._special_keywords:

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -863,7 +863,7 @@ class Card(_Verify):
                 if value.endswith("&"):
                     value = value[:-1]
 
-                if not comment:
+                if comment is None:
                     trailing = vc[m.end("strg") : m.end(0)]
                     if trailing:
                         trailing_spaces = trailing.replace("'", "")
@@ -871,7 +871,7 @@ class Card(_Verify):
                             value += trailing_spaces
 
                 remainder = vc[m.end(0) :]
-                if remainder and not comment:
+                if remainder and comment is None:
                     extra_value = remainder.rstrip()
                     if extra_value.endswith("'"):
                         extra_value = extra_value[:-1]

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -468,6 +468,69 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'xml'                                                                 "
         )
 
+    @pytest.mark.parametrize("comment", [None, "comment"])
+    def test_long_string_trailing_doubled_quotes_round_trip(self, comment):
+        for n in range(60, 100):
+            value = "x" * n + "''"
+            if comment is None:
+                card = fits.Card("CONFIG", value)
+                image = card.image
+            else:
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always", VerifyWarning)
+                    card = fits.Card("CONFIG", value, comment)
+                    image = card.image
+                emitted_warning = any(
+                    isinstance(w.message, VerifyWarning) for w in caught
+                )
+                if len(image) == card.length:
+                    assert emitted_warning
+                else:
+                    assert not emitted_warning
+            round_trip = fits.Card.fromstring(image)
+            assert round_trip.value == value
+            if comment is None:
+                assert round_trip.comment == ""
+            else:
+                if len(card.image) > card.length:
+                    assert round_trip.comment == comment
+                else:
+                    parts = card.image.split("/", 1)
+                    expected_comment = parts[1].strip() if len(parts) == 2 else ""
+                    assert round_trip.comment == expected_comment
+
+    def test_long_string_embedded_doubled_quotes_across_boundaries(self):
+        prefix = "A" * 48
+        suffix = "B" * 64
+        value = prefix + "''" + suffix
+        card = fits.Card("BOUND", value, "spans boundaries")
+        round_trip = fits.Card.fromstring(card.image)
+        assert round_trip.value == value
+        assert round_trip.comment == "spans boundaries"
+
+    @pytest.mark.parametrize(
+        "value, comment",
+        [
+            ("x" * 100 + "''", "comment"),
+            ("x" * 100 + "'' aaa", "comment"),
+        ],
+    )
+    def test_long_string_regression_cases_with_trailing_quotes(self, value, comment):
+        card = fits.Card("FOO", value, comment)
+        round_trip = fits.Card.fromstring(card.image)
+        assert round_trip.value == value
+        assert round_trip.comment == comment
+
+    def test_null_string_round_trip_including_continued_value(self):
+        card = fits.Card("NULL", "''")
+        round_trip = fits.Card.fromstring(card.image)
+        assert round_trip.value == "''"
+
+        long_value = "prefix-" + "y" * 48 + "''" + "z" * 48 + "-suffix"
+        long_card = fits.Card("NULL", long_value)
+        long_round_trip = fits.Card.fromstring(long_card.image)
+        assert long_round_trip.value == long_value
+
     def test_long_unicode_string(self):
         """Regression test for
         https://github.com/spacetelescope/PyFITS/issues/1


### PR DESCRIPTION
## Summary
- Preserve doubled single quotes ("''") across CONTINUE segments when parsing long string FITS Cards
- Defer unescaping until after full value reassembly; remove per-chunk unescape in `Card._split`
- Refine continuation handling: strip ampersand before recovery and avoid pulling in formatting spaces on comment cards
- Add regression tests for boundary lengths, embedded doubled quotes, null string cases, and comment interactions

## Observed Failure
Silent data corruption on round-trip of FITS Card values containing doubled quotes near 80-col boundaries:

- Trailing doubled quotes lose one quote at certain lengths:
```
65 False
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx''
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
67 False
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx''
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
68 False
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx''
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
69 False
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx''
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
```

- When `''` appears within a larger value, mismatches occur across a range of lengths (often around continuation boundaries):
```
55 67 False
56 68 False
57 69 False
58 70 False
59 71 False
60 72 False
61 73 False
62 74 False
63 75 False
65 77 False
67 79 False
68 80 False
69 81 False
```

- Additional reported cases:
  - Trailing quote at end of long line lost:
    - `fits.Card.fromstring(fits.Card("FOO", "x"*100 + "''", "comment").image).value` → returns a value ending with a single quote.
  - Text after doubled quotes lost if there is a space in between:
    - `fits.Card.fromstring(fits.Card("FOO", "x"*100 + "'' aaa", "comment").image).value` → truncates after the single quote.

## Reproduction Steps
Run any of the following in Python with astropy.io.fits:

```python
from astropy.io import fits

# 1) Doubled quotes at end
for n in range(60, 70):
    card1 = fits.Card('CONFIG', "x" * n + "''")
    card2 = fits.Card.fromstring(str(card1))
    assert card1.value == card2.value

# 2) Doubled quotes inside a longer string
for n in range(50, 70):
    card1 = fits.Card('CONFIG', "x" * n + "''" + "x" * 10)
    card2 = fits.Card.fromstring(str(card1))
    assert card1.value == card2.value

# 3) Additional cases
assert fits.Card.fromstring(fits.Card("FOO", "x"*100 + "''", "comment").image).value.endswith("''")
assert fits.Card.fromstring(fits.Card("FOO", "x"*100 + "'' aaa", "comment").image).value.endswith("'' aaa")
```

Expected: All assertions pass.
Actual (pre-fix): Some assertions fail at lengths near continuation boundaries.

## Stack Trace
No Python exception is raised; this is a silent parsing defect (logical data corruption). Therefore, no traceback is available. The failure is observable via round-trip mismatch as shown above.

## Implementation Notes
- Root cause: In `astropy/io/fits/card.py`, `Card._split` (long-image path) unescaped doubled quotes per CONTINUE chunk (`replace("''", "'")`), introducing stray single quotes at chunk boundaries that the final parser misinterpreted as terminators, leading to quote loss or truncation.
- Fix: Remove per-chunk unescape; let final parse unescape after full value reassembly. Ensure continuation ampersands are stripped before whitespace recovery, and skip whitespace recovery when a comment field is present.
- Serialization (`_format_value`, `_format_long_image`) unchanged; they already double embedded quotes correctly.

## Tests
- Added regression coverage in `astropy/io/fits/tests/test_header.py`:
  - Trailing doubled quotes near boundary lengths with and without comments
  - Embedded doubled quotes across boundaries within larger strings
  - Null string `''` round-trip, including within long continued values
  - Comment interaction cases (no spurious `&` or spaces)

Fixes #71