### PR TITLE
swev-id: astropy__astropy-8707 — Accept bytes in Header.fromstring/Card.fromstring

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -547,11 +547,20 @@ class Card(_Verify):
     @classmethod
     def fromstring(cls, image):
         """
-        Construct a `Card` object from a (raw) string. It will pad the string
-        if it is not the length of a card image (80 columns).  If the card
-        image is longer than 80 columns, assume it contains ``CONTINUE``
-        card(s).
+        Construct a `Card` object from a (raw) string or bytes. It will pad the
+        string if it is not the length of a card image (80 columns).  If the
+        card image is longer than 80 columns, assume it contains ``CONTINUE``
+        card(s).  ``bytes`` inputs are decoded using ASCII with
+        ``errors='strict'`` prior to parsing, unlike `Header.fromfile` which
+        may decode file content more permissively.
         """
+
+        if isinstance(image, bytes):
+            image = image.decode('ascii', 'strict')
+        elif not isinstance(image, str):
+            raise TypeError(
+                'Card.fromstring expected str or bytes, got {0}'.format(
+                    type(image).__name__))
 
         card = cls()
         card._image = _pad(image)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -329,13 +329,16 @@ class Header:
     @classmethod
     def fromstring(cls, data, sep=''):
         """
-        Creates an HDU header from a byte string containing the entire header
-        data.
+        Creates an HDU header from an in-memory FITS header representation.
 
         Parameters
         ----------
-        data : str
-           String containing the entire header.
+        data : str or bytes
+            Header content containing the entire header.  When ``bytes`` are
+            supplied they are decoded using ASCII with ``errors='strict'``
+            before parsing.  This differs from `Header.fromfile`, which may
+            apply a more permissive decoding policy when reading from file
+            handles.
 
         sep : str, optional
             The string separating cards from each other, such as a newline.  By
@@ -347,6 +350,13 @@ class Header:
         header
             A new `Header` instance.
         """
+
+        if isinstance(data, bytes):
+            data = data.decode('ascii', 'strict')
+        elif not isinstance(data, str):
+            raise TypeError(
+                'Header.fromstring expected str or bytes, got {0}'.format(
+                    type(data).__name__))
 
         cards = []
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -321,6 +321,27 @@ class TestHeaderFunctions(FitsTestCase):
                           match='Verification reported errors'):
             assert str(c) == _pad("XYZ     =                  100")
 
+    def test_card_fromstring_accepts_bytes(self):
+        card_image = str(fits.Card('TEST', 123))
+        card_bytes = card_image.encode('ascii')
+
+        card_from_str = fits.Card.fromstring(card_image)
+        card_from_bytes = fits.Card.fromstring(card_bytes)
+
+        assert card_from_str.keyword == 'TEST'
+        assert card_from_bytes.keyword == 'TEST'
+        assert card_from_bytes.value == 123
+
+    def test_card_fromstring_bytes_strict_ascii(self):
+        card_bytes = str(fits.Card('TEST', 123)).encode('ascii')
+        bad_bytes = card_bytes[:-1] + b'\xff'
+
+        with pytest.raises(UnicodeDecodeError):
+            fits.Card.fromstring(bad_bytes)
+
+        with pytest.raises(TypeError):
+            fits.Card.fromstring(123)
+
     def test_equal_only_up_to_column_10(self, capsys):
         # the test of "=" location is only up to column 10
 
@@ -870,6 +891,28 @@ class TestHeaderFunctions(FitsTestCase):
         assert 'A' in newheader
         assert 'C' not in newheader
         assert 'E' in newheader
+
+    def test_header_fromstring_accepts_bytes(self):
+        cards = [str(fits.Card('SIMPLE', True)), _pad('END')]
+        cases = [('', ''.join(cards)), ('\n', '\n'.join(cards))]
+
+        for sep, payload in cases:
+            header_from_str = fits.Header.fromstring(payload, sep=sep)
+            header_from_bytes = fits.Header.fromstring(
+                payload.encode('ascii'), sep=sep)
+
+            assert header_from_str['SIMPLE'] is True
+            assert header_from_bytes['SIMPLE'] is True
+
+    def test_header_fromstring_bytes_strict_ascii(self):
+        header_bytes = (str(fits.Card('SIMPLE', True)) + _pad('END')).encode('ascii')
+        bad_bytes = header_bytes[:-1] + b'\xff'
+
+        with pytest.raises(UnicodeDecodeError):
+            fits.Header.fromstring(bad_bytes)
+
+        with pytest.raises(TypeError):
+            fits.Header.fromstring(123)
 
     def test_header_slice_assignment(self):
         """


### PR DESCRIPTION
## Summary
- allow Header.fromstring and Card.fromstring to accept bytes input decoded via strict ASCII
- document the accepted input types and decoding behavior in both docstrings
- add regression tests covering str/bytes success paths and UnicodeDecodeError on non-ASCII input

## Testing
- .venv/bin/flake8 --select=E9,F63,F7,F82 astropy/io/fits/header.py astropy/io/fits/card.py astropy/io/fits/tests/test_header.py
- LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib .venv/bin/pytest astropy/io/fits/tests/test_header.py -k "card_fromstring_accepts_bytes or card_fromstring_bytes_strict_ascii or header_fromstring_accepts_bytes or header_fromstring_bytes_strict_ascii"

Fixes #92