### PR TITLE
Preserve inexact dtype in Quantity construction (swev-id: astropy__astropy-8872)

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -296,8 +296,10 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                 if not copy:
                     return value
 
-                if not (np.can_cast(np.float32, value.dtype) or
-                        value.dtype.fields):
+                if not (
+                    np.issubdtype(value.dtype, np.inexact)
+                    or value.dtype.fields
+                ):
                     dtype = float
 
             return np.array(value, dtype=dtype, copy=copy, order=order,
@@ -377,9 +379,13 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                             "Numpy numeric type.")
 
         # by default, cast any integer, boolean, etc., to float
-        if dtype is None and (not (np.can_cast(np.float32, value.dtype)
-                                   or value.dtype.fields)
-                              or value.dtype.kind == 'O'):
+        if dtype is None and (
+            not (
+                np.issubdtype(value.dtype, np.inexact)
+                or value.dtype.fields
+            )
+            or value.dtype.kind == 'O'
+        ):
             value = value.astype(float)
 
         value = value.view(cls)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -150,6 +150,46 @@ class TestQuantityCreation:
         q5 = u.Quantity(decimal.Decimal('10.25'), u.m, dtype=object)
         assert q5.dtype == object
 
+    def test_float16_dtype_preservation(self):
+        scalar = np.float16(1)
+        quantity = scalar * u.km
+        assert quantity.dtype == np.dtype('float16')
+
+        constructed = u.Quantity(np.float16(2), u.m)
+        assert constructed.dtype == np.dtype('float16')
+
+        array = np.array([1, 2, 3], dtype=np.float16)
+        array_quantity = u.Quantity(array, u.s)
+        assert array_quantity.dtype == array.dtype
+
+    def test_float16_respects_explicit_dtype(self):
+        value = np.float16(1)
+        q_float32 = u.Quantity(value, u.m, dtype=np.float32)
+        assert q_float32.dtype == np.dtype('float32')
+
+        q_float16 = u.Quantity(value, u.m, dtype=np.float16)
+        assert q_float16.dtype == np.dtype('float16')
+
+    def test_int_and_bool_inputs_default_to_float64(self):
+        q_int = u.Quantity(5, u.m)
+        assert q_int.dtype == np.dtype('float64')
+
+        q_bool = u.Quantity(True, u.s)
+        assert q_bool.dtype == np.dtype('float64')
+
+        array = np.array([1, 2, 3], dtype=np.int16)
+        q_array = u.Quantity(array, u.cm)
+        assert q_array.dtype == np.dtype('float64')
+
+    def test_other_inexact_dtypes_preserved(self):
+        float32_array = np.array([1.0], dtype=np.float32)
+        float32_quantity = u.Quantity(float32_array, u.m)
+        assert float32_quantity.dtype == float32_array.dtype
+
+        complex64_array = np.array([1.0 + 2.0j], dtype=np.complex64)
+        complex64_quantity = u.Quantity(complex64_array, u.s)
+        assert complex64_quantity.dtype == complex64_array.dtype
+
     def test_copy(self):
 
         # By default, a new quantity is constructed, but not if copy=False


### PR DESCRIPTION
## Summary
- replace `np.can_cast(np.float32, ...)` checks with `np.issubdtype(..., np.inexact)` so inexact inputs keep their dtype
- add regression coverage for float16 scalars/arrays, explicit dtype overrides, integer/bool casting, and other inexact dtypes

## Issue Link
- #104

## Reproduction (before fix)
Command:
```
SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib:${LD_LIBRARY_PATH} .venv/bin/pytest astropy/units/tests/test_quantity.py -k 'float16 or default_to_float64' -vv
```
Failure excerpt:
```
astropy/units/tests/test_quantity.py::TestQuantityCreation::test_float16_dtype_preservation FAILED
E       AssertionError: assert dtype('float64') == dtype('float16')
```

## Testing (after fix)
```
SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib:${LD_LIBRARY_PATH} .venv/bin/pytest astropy/units/tests/test_quantity.py -k 'float16 or default_to_float64 or inexact' -vv
git diff --unified=0 origin/astropy__astropy-8872 -- astropy/units/quantity.py astropy/units/tests/test_quantity.py | SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib:${LD_LIBRARY_PATH} .venv/bin/flake8 --diff
```