### PR TITLE
swev-id: astropy__astropy-14309 Fix is_fits identifier guard

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -40,6 +40,15 @@ REMOVE_KEYWORDS = [
 # Column-specific keywords regex
 COLUMN_KEYWORD_REGEXP = "(" + "|".join(KEYWORD_NAMES) + ")[0-9]+"
 
+FITS_EXTENSIONS = (
+    ".fits",
+    ".fits.gz",
+    ".fit",
+    ".fit.gz",
+    ".fts",
+    ".fts.gz",
+)
+
 
 def is_column_keyword(keyword):
     return re.match(COLUMN_KEYWORD_REGEXP, keyword) is not None
@@ -47,29 +56,53 @@ def is_column_keyword(keyword):
 
 def is_fits(origin, filepath, fileobj, *args, **kwargs):
     """
-    Determine whether `origin` is a FITS file.
+    Determine whether the provided inputs correspond to FITS data.
 
     Parameters
     ----------
-    origin : str or readable file-like
-        Path or file object containing a potential FITS file.
+    origin : {"read", "write"}
+        Operation being performed.
+    filepath : str or path-like, optional
+        Path associated with the operation, if available.
+    fileobj : file-like, optional
+        Open file object to inspect when reading.
+    *args, **kwargs
+        Additional arguments accepted for compatibility; unused.
 
     Returns
     -------
-    is_fits : bool
-        Returns `True` if the given file is a FITS file.
+    is_fits : bool or None
+        ``True`` when the inputs conclusively represent FITS data, ``False``
+        when a FITS signature check fails, and ``None`` when the format cannot
+        be determined.
     """
+
+    mode = (origin or "").lower()
+    is_read = mode == "read"
+    is_write = mode == "write"
+
     if fileobj is not None:
         pos = fileobj.tell()
-        sig = fileobj.read(30)
+        sig = fileobj.read(len(FITS_SIGNATURE))
         fileobj.seek(pos)
-        return sig == FITS_SIGNATURE
-    elif filepath is not None:
-        if filepath.lower().endswith(
-            (".fits", ".fits.gz", ".fit", ".fit.gz", ".fts", ".fts.gz")
-        ):
+        if sig == FITS_SIGNATURE:
             return True
-    return isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU))
+        if is_read:
+            return False
+        return None
+
+    if filepath is not None:
+        filepath_lower = filepath.lower()
+        if filepath_lower.endswith(FITS_EXTENSIONS):
+            return True
+        if is_write:
+            return None
+
+    if is_read and len(args) > 0:
+        if isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU)):
+            return True
+
+    return None
 
 
 def _decode_mixins(tbl):

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
-from astropy.io import fits
+from astropy.io import fits, registry
 from astropy.io.fits import BinTableHDU, HDUList, ImageHDU, PrimaryHDU, table_to_hdu
 from astropy.io.fits.column import (
     _fortran_to_python_format,
@@ -75,6 +75,12 @@ def test_is_fits_read_signature_mismatch():
 
 def test_is_fits_read_without_args_guard():
     assert is_fits("read", None, None) is None
+
+
+def test_identify_format_read_with_hdulist_arg():
+    hdu_list = HDUList([PrimaryHDU()])
+    identified = registry.identify_format("read", Table, None, None, [hdu_list], {})
+    assert identified == ["fits"]
 
 
 class TestSingleTable:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1,4 +1,5 @@
 import gc
+import io
 import warnings
 
 import numpy as np
@@ -13,6 +14,8 @@ from astropy.io.fits.column import (
     _parse_tdisp_format,
     python_to_tdisp,
 )
+from astropy.io.fits.connect import is_fits
+from astropy.io.fits.hdu.hdulist import FITS_SIGNATURE
 from astropy.io.tests.mixin_columns import compare_attrs, mixin_cols, serialized_names
 from astropy.table import Column, QTable, Table
 from astropy.table.table_helpers import simple_table
@@ -51,6 +54,27 @@ mixin_cols = {
 
 def equal_data(a, b):
     return all(np.all(a[name] == b[name]) for name in a.dtype.names)
+
+
+def test_is_fits_write_non_fits_path():
+    assert is_fits("write", "example.ecsv", None) is None
+
+
+def test_is_fits_write_with_fits_extension():
+    assert is_fits("write", "example.fits", None) is True
+
+
+def test_is_fits_read_with_signature():
+    fileobj = io.BytesIO(FITS_SIGNATURE + b" remainder")
+    assert is_fits("read", None, fileobj) is True
+
+
+def test_is_fits_read_signature_mismatch():
+    assert is_fits("read", None, io.BytesIO(b"not fits")) is False
+
+
+def test_is_fits_read_without_args_guard():
+    assert is_fits("read", None, None) is None
 
 
 class TestSingleTable:


### PR DESCRIPTION
## Summary
- guard astropy.io.fits is_fits for read/write origin semantics
- prevent write-mode identify_format calls from touching absent args and rely on extensions
- add regression tests covering new detection logic and signature failures

## Testing
- SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/pytest astropy/io/fits/tests/test_connect.py -k is_fits
- SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 astropy/io/fits/connect.py astropy/io/fits/tests/test_connect.py

Refs #106