### PR TITLE
swev-id: astropy__astropy-14365 - ascii.qdp: accept lowercase/mixed-case QDP commands (READ SERR/TERR)

### DIFF
--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -60,7 +60,7 @@ def _line_type(line, delimiter=None):
     ValueError: Unrecognized QDP line...
     """
     _decimal_re = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
-    _command_re = r"READ [TS]ERR(\s+[0-9]+)+"
+    _command_re = r"(?i:READ [TS]ERR(\s+[0-9]+)+)"
 
     sep = delimiter
     if delimiter is None:

--- a/astropy/io/ascii/tests/test_qdp.py
+++ b/astropy/io/ascii/tests/test_qdp.py
@@ -139,6 +139,31 @@ def test_read_example():
         assert np.allclose(col1, col2, equal_nan=True)
 
 
+def test_lowercase_read_commands(tmp_path):
+    example_qdp = """
+        ! Lowercase commands describing error columns
+        read terr 1
+        read serr 2
+        ! Columns: x, x errors, y, y error
+        1.0 0.1 -0.2 5.0 0.5
+        2.0 0.2 -0.3 6.0 0.6
+        NO NO NO NO NO
+        """
+
+    path = tmp_path / "lowercase.qdp"
+
+    with open(path, "w") as fp:
+        print(example_qdp, file=fp)
+
+    table = Table.read(path, format="ascii.qdp", names=["x", "y"], table_id=0)
+
+    assert np.allclose(table["x"], [1.0, 2.0])
+    assert np.allclose(table["x_perr"], [0.1, 0.2])
+    assert np.allclose(table["x_nerr"], [-0.2, -0.3])
+    assert np.allclose(table["y"], [5.0, 6.0])
+    assert np.allclose(table["y_err"], [0.5, 0.6])
+
+
 def test_roundtrip_example(tmp_path):
     example_qdp = """
         ! Initial comment line 1


### PR DESCRIPTION
## Summary
- make the READ SERR/TERR command pattern case-insensitive with a scoped inline flag
- add regression coverage reading lowercase directives to confirm error column parsing

## Testing
- `SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/python -m pytest astropy/io/ascii/tests/test_qdp.py`
- `SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib .venv/bin/flake8 astropy/io/ascii/qdp.py astropy/io/ascii/tests/test_qdp.py --per-file-ignores='astropy/units/tests/test_units.py:F841,E501,E711,E222'`

## Reproduction
```
# Create test.qdp
read serr 1 2
1 0.5 1 0.5
```

## Observed error
```
>>> from astropy.table import Table
>>> Table.read('test.qdp', format='ascii.qdp')
WARNING: table_id not specified. Reading the first available table [astropy.io.ascii.qdp]
Traceback (most recent call last):
...
ValueError: Unrecognized QDP line: read serr 1 2
```

Fixes #115