### PR TITLE
swev-id: astropy__astropy-14365 accept lowercase QDP commands

### DIFF
--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -60,7 +60,7 @@ def _line_type(line, delimiter=None):
     ValueError: Unrecognized QDP line...
     """
     _decimal_re = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
-    _command_re = r"READ [TS]ERR(\s+[0-9]+)+"
+    _command_re = r"(?i:READ\s+[TS]ERR(?:\s+\d+)+)"
 
     sep = delimiter
     if delimiter is None:
@@ -293,11 +293,15 @@ def _get_tables_from_qdp_file(qdp_file, input_colnames=None, delimiter=None):
             # The first time I find data, I define err_specs
             if err_specs == {} and command_lines != "":
                 for cline in command_lines.strip().split("\n"):
+                    cline = cline.split("!", 1)[0]
                     command = cline.strip().split()
                     # This should never happen, but just in case.
                     if len(command) < 3:
                         continue
-                    err_specs[command[1].lower()] = [int(c) for c in command[2:]]
+                    keyword = command[1].lower()
+                    if keyword not in {"serr", "terr"}:
+                        raise ValueError(f"Unrecognized QDP command: {command[1]}")
+                    err_specs[keyword] = [int(c) for c in command[2:]]
             if colnames is None:
                 colnames = _interpret_err_lines(err_specs, ncol, names=input_colnames)
 
@@ -553,7 +557,8 @@ class QDP(basic.Basic):
     which mean that after data column 1 there will be two error columns
     containing its positive and engative error bars, then data column 2 without
     error bars, then column 3, then a column with the symmetric error of column
-    3, then the remaining data columns.
+    3, then the remaining data columns. The ``READ SERR`` and ``READ TERR``
+    commands are parsed case-insensitively.
 
     As explained below, table headers are highly inconsistent. Possible
     comments containing column names will be ignored and columns will be called

--- a/astropy/io/ascii/tests/test_qdp.py
+++ b/astropy/io/ascii/tests/test_qdp.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import numpy as np
 import pytest
 
@@ -5,6 +7,121 @@ from astropy.io import ascii
 from astropy.io.ascii.qdp import _get_lines_from_file, _read_table_qdp, _write_table_qdp
 from astropy.table import Column, MaskedColumn, Table
 from astropy.utils.exceptions import AstropyUserWarning
+
+
+@pytest.mark.parametrize(
+    "command_line",
+    ["read serr 1 2", "ReAd SeRr 1 2"],
+    ids=["lower", "mixed"],
+)
+def test_qdp_read_serr_case_insensitive(command_line):
+    qdp_text = textwrap.dedent(
+        f"""
+        {command_line}
+        10 0.1 20 0.2
+        30 0.3 40 0.4
+        """
+    ).strip()
+
+    table = _read_table_qdp(qdp_text, names=["c1", "c2"], table_id=0)
+
+    assert table.colnames == ["c1", "c1_err", "c2", "c2_err"]
+    assert np.allclose(table["c1"], [10, 30])
+    assert np.allclose(table["c1_err"], [0.1, 0.3])
+    assert np.allclose(table["c2"], [20, 40])
+    assert np.allclose(table["c2_err"], [0.2, 0.4])
+
+
+@pytest.mark.parametrize(
+    (
+        "command_lines",
+        "names",
+        "expected_colnames",
+        "expected_checks",
+        "data_lines",
+    ),
+    [
+        (
+            ["read    terr    1     3"],
+            ["col1", "col2", "col3"],
+            [
+                "col1",
+                "col1_perr",
+                "col1_nerr",
+                "col2",
+                "col3",
+                "col3_perr",
+                "col3_nerr",
+            ],
+            {
+                "col1_perr": [0.1, 0.6],
+                "col1_nerr": [0.2, 0.7],
+                "col3": [3, 6],
+                "col3_perr": [0.4, 0.8],
+                "col3_nerr": [0.5, 0.9],
+            },
+            [
+                "1 0.1 0.2 2 3 0.4 0.5",
+                "4 0.6 0.7 5 6 0.8 0.9",
+            ],
+        ),
+        (
+            ["read serr 2", "read terr 1 ! trailing comment"],
+            ["x", "y"],
+            ["x", "x_perr", "x_nerr", "y", "y_err"],
+            {
+                "x_perr": [0.1, 0.4],
+                "x_nerr": [0.2, 0.5],
+                "y_err": [0.3, 0.6],
+            },
+            [
+                "10 0.1 0.2 20 0.3",
+                "30 0.4 0.5 40 0.6",
+            ],
+        ),
+    ],
+    ids=["terr_spacing", "inline_comment"],
+)
+def test_qdp_read_terr_variants(
+    command_lines, names, expected_colnames, expected_checks, data_lines
+):
+    qdp_text = textwrap.dedent(
+        "\n".join(command_lines + data_lines)
+    ).strip()
+
+    table = _read_table_qdp(qdp_text, names=names, table_id=0)
+
+    assert table.colnames == expected_colnames
+    for column, values in expected_checks.items():
+        assert np.allclose(table[column], values)
+
+
+def test_qdp_data_lines_without_commands_are_parsed():
+    qdp_text = textwrap.dedent(
+        """
+        ! pure data follows
+        1 2
+        3 4
+        """
+    ).strip()
+
+    table = _read_table_qdp(qdp_text, names=["c1", "c2"], table_id=0)
+
+    assert table.colnames == ["c1", "c2"]
+    assert np.allclose(table["c1"], [1, 3])
+    assert np.allclose(table["c2"], [2, 4])
+
+
+def test_qdp_unknown_command_raises():
+    qdp_text = textwrap.dedent(
+        """
+        read xerr 1 2
+        1 2 3 4
+        """
+    ).strip()
+
+    with pytest.raises(ValueError, match="Unrecognized QDP"):
+        _read_table_qdp(qdp_text, names=["a", "b"], table_id=0)
 
 
 def test_get_tables_from_qdp_file(tmp_path):


### PR DESCRIPTION
## Summary
- make QDP command detection case-insensitive and reject unknown directives
- strip inline comments before parsing READ SERR/TERR arguments
- document the behavior and add regression tests for command variations

## Observed Failure
- Steps to reproduce:
  ```
  cat > test.qdp <<'QDP'
  read serr 1 2
  1 0.5 1 0.5
  QDP
  python - <<'PY'
  from astropy.table import Table
  Table.read('test.qdp', format='ascii.qdp')
  PY
  ```
- Stack trace excerpt:
  ```
  ValueError: Unrecognized QDP line: read serr 1 2
  ```

## Testing
- `LD_LIBRARY_PATH=/nix/store/wffgswxkp55xi14jy63rjsnfvl2qvmxy-gcc-14.3.0-lib/lib:/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/zmjqwzhgl9hwr8xnk8raj8d50lzkql66-gcc-14.3.0-lib/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib SETUPTOOLS_USE_DISTUTILS=stdlib PYTHONPATH=. .venv/bin/pytest astropy/io/ascii/tests/test_qdp.py -k qdp`
- `SETUPTOOLS_USE_DISTUTILS=stdlib .venv/bin/flake8 astropy/io/ascii/qdp.py astropy/io/ascii/tests/test_qdp.py --per-file-ignores='astropy/units/tests/test_units.py:F841,E501,E222,E711'`

Resolves #119.