### PR TITLE
Support header_rows in ascii.rst writer (swev-id: astropy__astropy-14182)

### DIFF
--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -57,10 +57,79 @@ class RST(FixedWidth):
     data_class = SimpleRSTData
     header_class = SimpleRSTHeader
 
-    def __init__(self):
-        super().__init__(delimiter_pad=None, bookend=False)
+    def __init__(self, header_rows=None):
+        if header_rows is not None and len(header_rows) == 0:
+            raise TypeError("RST writer requires at least one header row.")
+        super().__init__(delimiter_pad=None, bookend=False, header_rows=header_rows)
 
-    def write(self, lines):
-        lines = super().write(lines)
-        lines = [lines[1]] + lines + [lines[1]]
-        return lines
+    def write(self, table):
+        header_rows = getattr(self.header, "header_rows", ["name"])
+        if not header_rows:
+            raise TypeError("RST writer requires at least one header row.")
+
+        lines = super().write(table)
+
+        prefix_len = 0
+        while prefix_len < len(lines) and (
+            not lines[prefix_len].strip() or lines[prefix_len].startswith("#")
+        ):
+            prefix_len += 1
+
+        prefix = lines[:prefix_len]
+        body = lines[prefix_len:]
+
+        if len(header_rows) == 1:
+            if len(body) <= len(header_rows):
+                return lines
+            border_line = body[len(header_rows)]
+            return prefix + [border_line] + body + [border_line]
+
+        cols = self.data.cols
+
+        header_values = []
+        for attr in header_rows:
+            row = []
+            for col in cols:
+                value = getattr(col.info, attr, None)
+                row.append("" if value is None else str(value))
+            header_values.append(row)
+
+        data_rows = list(zip(*[col.str_vals for col in cols])) if cols else []
+
+        widths = []
+        for idx, col in enumerate(cols):
+            width = 0
+            for row in header_values:
+                width = max(width, len(row[idx]))
+            for row in data_rows:
+                width = max(width, len(row[idx]))
+            widths.append(max(1, width))
+
+        def make_border(fill_char):
+            segments = [fill_char * (width + 2) for width in widths]
+            return "+" + "+".join(segments) + "+"
+
+        def format_row(row):
+            cells = [
+                " " + value.rjust(width) + " "
+                for value, width in zip(row, widths)
+            ]
+            return "|" + "|".join(cells) + "|"
+
+        grid_lines = [make_border("-")]
+
+        for idx, row in enumerate(header_values):
+            grid_lines.append(format_row(row))
+            if idx < len(header_values) - 1:
+                grid_lines.append(make_border("-"))
+
+        grid_lines.append(make_border("="))
+
+        if data_rows:
+            for row in data_rows:
+                grid_lines.append(format_row(row))
+                grid_lines.append(make_border("-"))
+        else:
+            grid_lines.append(make_border("-"))
+
+        return prefix + grid_lines

--- a/astropy/io/ascii/tests/test_rst_header_rows.py
+++ b/astropy/io/ascii/tests/test_rst_header_rows.py
@@ -1,0 +1,114 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+
+from astropy import units as u
+from astropy.io.ascii.rst import RST
+from astropy.table import QTable, Table
+
+
+def _split_lines(text):
+    return text.splitlines()
+
+
+def test_header_rows_empty_error():
+    with pytest.raises(TypeError, match="RST writer requires at least one header row."):
+        RST(header_rows=[])
+
+    writer = RST()
+    writer.header.header_rows = []
+    table = Table({"a": [1]})
+
+    with pytest.raises(TypeError, match="RST writer requires at least one header row."):
+        writer.write(table)
+
+
+def test_single_header_row_default_names():
+    table = Table(
+        {
+            "Col1": [1.2, 2.4],
+            "Col2": ['"hello"', "'s worlds"],
+            "Col3": [1, 2],
+            "Col4": ["a", "2"],
+        }
+    )
+
+    lines = RST().write(table)
+
+    expected = _split_lines(
+        """\
+==== ========= ==== ====
+Col1      Col2 Col3 Col4
+==== ========= ==== ====
+ 1.2   "hello"    1    a
+ 2.4 's worlds    2    2
+==== ========= ==== ====
+"""
+    )
+
+    assert lines == expected
+
+
+def test_single_header_row_units_only():
+    table = QTable({"a": [1, 2] * u.m, "bbb": [3, 4] * u.s})
+
+    lines = RST(header_rows=["unit"]).write(table)
+
+    expected = _split_lines(
+        """\
+=== ===
+  m   s
+=== ===
+1.0 3.0
+2.0 4.0
+=== ===
+"""
+    )
+
+    assert lines == expected
+
+
+def test_two_header_rows_grid_table():
+    table = QTable({"a": [1, 2] * u.m, "bbb": [3, 4] * u.s})
+
+    lines = RST(header_rows=["name", "unit"]).write(table)
+
+    expected = _split_lines(
+        """\
++-----+-----+
+|   a | bbb |
++-----+-----+
+|   m |   s |
++=====+=====+
+| 1.0 | 3.0 |
++-----+-----+
+| 2.0 | 4.0 |
++-----+-----+
+"""
+    )
+
+    assert lines == expected
+
+
+def test_three_header_rows_alignment():
+    table = QTable({"a": [1, 2] * u.m, "bbb": [3, 4] * u.s})
+
+    lines = RST(header_rows=["dtype", "name", "unit"]).write(table)
+
+    expected = _split_lines(
+        """\
++---------+---------+
+| float64 | float64 |
++---------+---------+
+|       a |     bbb |
++---------+---------+
+|       m |       s |
++=========+=========+
+|     1.0 |     3.0 |
++---------+---------+
+|     2.0 |     4.0 |
++---------+---------+
+"""
+    )
+
+    assert lines == expected


### PR DESCRIPTION
## Summary
- add header_rows plumbing to the RST writer
- render multi-row headers as grid tables and extend coverage

## Testing
- pytest astropy/io/ascii/tests/test_rst.py::test_write_normal
- pytest astropy/io/ascii/tests/test_rst_header_rows.py

Refs #113