### PR TITLE
io.fits.Card: shortest-roundtrip float formatting [skip ci] (swev-id: astropy__astropy-14508)

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -1298,32 +1298,25 @@ def _format_value(value):
 
 
 def _format_float(value):
-    """Format a floating number to make sure it gets the decimal point."""
-    value_str = f"{value:.16G}"
-    if "." not in value_str and "E" not in value_str:
-        value_str += ".0"
-    elif "E" in value_str:
-        # On some Windows builds of Python (and possibly other platforms?) the
-        # exponent is zero-padded out to, it seems, three digits.  Normalize
-        # the format to pad only to two digits.
-        significand, exponent = value_str.split("E")
-        if exponent[0] in ("+", "-"):
-            sign = exponent[0]
-            exponent = exponent[1:]
-        else:
-            sign = ""
-        value_str = f"{significand}E{sign}{int(exponent):02d}"
+    """Return the FITS representation for a floating-point value."""
+    float_value = float(value)
 
-    # Limit the value string to at most 20 characters.
-    str_len = len(value_str)
+    if np.isnan(float_value):
+        return "NAN.0"
 
-    if str_len > 20:
-        idx = value_str.find("E")
+    if np.isinf(float_value):
+        sign = "-" if np.signbit(float_value) else ""
+        return f"{sign}INF.0"
 
-        if idx < 0:
-            value_str = value_str[:20]
-        else:
-            value_str = value_str[: 20 - (str_len - idx)] + value_str[idx:]
+    value_str = str(float_value).replace("e", "E")
+
+    if len(value_str) <= 20:
+        return value_str
+
+    for precision in range(17, 0, -1):
+        candidate = format(float_value, f".{precision}G").replace("e", "E")
+        if len(candidate) <= 20 and float(candidate) == float_value:
+            return candidate
 
     return value_str
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2,6 +2,7 @@
 
 import collections
 import copy
+import sys
 import warnings
 from io import BytesIO, StringIO
 
@@ -9,7 +10,7 @@ import numpy as np
 import pytest
 
 from astropy.io import fits
-from astropy.io.fits.card import _pad
+from astropy.io.fits.card import _format_float, _pad
 from astropy.io.fits.header import _pad_length
 from astropy.io.fits.util import encode_ascii
 from astropy.io.fits.verify import VerifyError, VerifyWarning
@@ -62,6 +63,64 @@ def test_init_with_ordereddict():
     h1 = fits.Header(dict1)
     # Check that the order is preserved of the initial list
     assert all(h1[val] == list1[i][1] for i, val in enumerate(h1))
+
+
+def test_card_float_shortest_roundtrip_no_truncation():
+    comment = "[m] radius arround actuator to avoid"
+    with warnings.catch_warnings(record=True) as caught:
+        card = fits.Card("HIERARCH ESO IFM CL RADIUS", 0.009125, comment)
+
+    verify_warnings = [w for w in caught if issubclass(w.category, VerifyWarning)]
+    assert verify_warnings == []
+
+    value_field = (
+        str(card).split("=", 1)[1].split("/", 1)[0].strip()
+    )
+    assert value_field == "0.009125"
+    assert card.comment == comment
+
+
+@pytest.mark.parametrize("exponent", (-60, 0, 60))
+def test_card_float_boundary_roundtrip(exponent):
+    value = (1 - 2 ** -53) * (2 ** exponent)
+    card = fits.Card("TEST", value)
+
+    value_field = (
+        str(card).split("=", 1)[1].split("/", 1)[0].strip()
+    )
+    expected = str(value).replace("e", "E")
+
+    assert value_field == expected
+
+    parsed = fits.Card.fromstring(str(card))
+    assert parsed.value == value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        (float("nan"), "NAN.0"),
+        (float("inf"), "INF.0"),
+        (-float("inf"), "-INF.0"),
+    ),
+)
+def test_format_float_special_tokens_preserved(value, expected):
+    assert _format_float(value) == expected
+
+
+def test_card_float_long_value_prefers_str():
+    value = sys.float_info.max
+    card = fits.Card("TEST", value)
+
+    value_field = (
+        str(card).split("=", 1)[1].split("/", 1)[0].strip()
+    )
+    expected = str(value).replace("e", "E")
+
+    assert value_field == expected
+
+    parsed = fits.Card.fromstring(str(card))
+    assert parsed.value == value
 
 
 class TestHeaderFunctions(FitsTestCase):


### PR DESCRIPTION
Summary
- Fix float formatting in astropy.io.fits Card to avoid unnecessary expansion (e.g., 0.009125 -> 0.009124999999999999) that causes comment truncation.
- Use Python’s shortest-roundtrip str() for finite floats, normalize exponent to 'E'. If str(value) exceeds 20 chars, attempt a compact G-format fallback that still round-trips; otherwise keep str(value).

Issue
- https://github.com/agyn-sandbox/astropy/issues/114

Observed failure (before fix)
- Creating a Card with value 0.009125 expanded to 0.009124999999999999 and emitted VerifyWarning: comment truncated.

Reproduction
```python
from astropy.io import fits
from astropy.io.fits.verify import VerifyWarning
import warnings
with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always", VerifyWarning)
    card = fits.Card(
        "HIERARCH ESO IFM CL RADIUS",
        0.009125,
        "[m] radius arround actuator to avoid",
    )
print([str(w.message) for w in caught])
print(str(card))
```
Output (pre-fix):
```
warnings: ["Card is too long, comment will be truncated."]
HIERARCH ESO IFM CL RADIUS = 0.009124999999999999 / [m] radius arround actuator 
```

Validation (after fix)
- Warnings: []
- String: `HIERARCH ESO IFM CL RADIUS = 0.009125 / [m] radius arround actuator to avoid    `

Tests added
- Regression for 0.009125 with full comment.
- Boundary values: (1 - 2**-53) * 2**exp for exp in [-60, 0, 60].
- Special tokens preserved for NaN/Inf/-Inf.
- Long representation keeps shortest-roundtrip str for sys.float_info.max.

Notes
- Title includes required token. Base branch: astropy__astropy-14508. CI is skipped via commit message.