### PR TITLE
fix: propagate SkyCoord descriptor AttributeError (swev-id: astropy__astropy-14096)

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import operator
 import re
 import warnings
@@ -871,6 +872,13 @@ class SkyCoord(ShapedLikeNDArray):
         Overrides getattr to return coordinates that this can be transformed
         to, based on the alias attr in the primary transform graph.
         """
+        try:
+            inspect.getattr_static(self, attr)
+        except AttributeError:
+            pass
+        else:
+            return object.__getattribute__(self, attr)
+
         if "_sky_coord_frame" in self.__dict__:
             if self._is_name(attr):
                 return self  # Should this be a deepcopy of self?

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -2165,3 +2165,35 @@ def test_match_to_catalog_3d_and_sky():
     npt.assert_array_equal(idx, [0, 1, 2, 3])
     assert_allclose(angle, 0 * u.deg, atol=1e-14 * u.deg, rtol=0)
     assert_allclose(distance, 0 * u.kpc, atol=1e-14 * u.kpc, rtol=0)
+
+
+def test_subclass_property_attribute_error_propagates():
+    class CustomSkyCoord(SkyCoord):
+        @property
+        def prop(self):
+            return self.random_attr
+
+    coord = CustomSkyCoord(RA, DEC, frame="icrs")
+
+    with pytest.raises(AttributeError) as excinfo:
+        coord.prop
+
+    message = str(excinfo.value)
+    assert "random_attr" in message
+    assert "prop" not in message
+
+
+def test_transform_alias_access_unchanged():
+    coord = SkyCoord(RA, DEC, frame="galactic")
+
+    transformed = coord.icrs
+
+    assert isinstance(transformed, SkyCoord)
+    assert transformed.frame.name == "icrs"
+
+
+def test_frame_attribute_delegation_unchanged():
+    obstime = Time("J2010")
+    coord = SkyCoord(RA, DEC, frame="fk5", obstime=obstime)
+
+    assert coord.obstime is obstime


### PR DESCRIPTION
## Summary
- ensure `SkyCoord.__getattr__` performs a static descriptor check before falling back to dynamic frame logic so subclass properties surface their own AttributeError
- add regression coverage for subclass descriptors, transform alias access, and frame attribute delegation

## Reproduction / Observed Failure
```python
import astropy.coordinates as coord

class custom_coord(coord.SkyCoord):
    @property
    def prop(self):
        return self.random_attr

c = custom_coord('00h42m30s', '+41d12m00s', frame='icrs')
c.prop
```

Observed prior to this change:
```
AttributeError: 'custom_coord' object has no attribute 'prop'
```

## Verification Notes
- transform alias access (e.g., `SkyCoord.icrs`) continues to round-trip
- frame attribute delegation (e.g., `SkyCoord.obstime`) continues to expose frame metadata

Resolves #116.