### PR TITLE
Support header_rows in ascii.rst (reStructuredText) writer [swev-id: astropy__astropy-14182]

### DIFF
--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -57,10 +57,16 @@ class RST(FixedWidth):
     data_class = SimpleRSTData
     header_class = SimpleRSTHeader
 
-    def __init__(self):
-        super().__init__(delimiter_pad=None, bookend=False)
+    def __init__(self, header_rows=None):
+        super().__init__(
+            delimiter_pad=None, bookend=False, header_rows=header_rows
+        )
 
     def write(self, lines):
         lines = super().write(lines)
-        lines = [lines[1]] + lines + [lines[1]]
+        header_rows = getattr(self.header, "header_rows", ["name"])
+        n_hdr = len(header_rows)
+        if self.header.position_line is not None:
+            separator = lines[n_hdr]
+            lines = [separator] + lines + [separator]
         return lines

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -2,7 +2,9 @@
 
 from io import StringIO
 
+import astropy.units as u
 from astropy.io import ascii
+from astropy.table import MaskedColumn, QTable
 
 from .common import assert_almost_equal, assert_equal
 
@@ -185,3 +187,108 @@ Col1      Col2 Col3 Col4
 ==== ========= ==== ====
 """,
     )
+
+
+def test_rst_header_rows_name_unit():
+    tbl = QTable(
+        {
+            "wave": [350, 950] * u.nm,
+            "response": [0.7, 1.2] * u.count,
+        }
+    )
+    out = StringIO()
+    ascii.write(tbl, out, format="rst", header_rows=["name", "unit"])
+    expected = (
+        "===== ========\n"
+        " wave response\n"
+        "   nm       ct\n"
+        "===== ========\n"
+        "350.0      0.7\n"
+        "950.0      1.2\n"
+        "===== ========\n"
+    )
+    assert_equal_splitlines(out.getvalue(), expected)
+
+
+def test_rst_header_rows_missing_units():
+    tbl = QTable(
+        {
+            "wave": [350, 950] * u.nm,
+            "response": [0.7, 1.2],
+        }
+    )
+    out = StringIO()
+    ascii.write(tbl, out, format="rst", header_rows=["name", "unit"])
+    expected = (
+        "===== ========\n"
+        " wave response\n"
+        "   nm         \n"
+        "===== ========\n"
+        "350.0      0.7\n"
+        "950.0      1.2\n"
+        "===== ========\n"
+    )
+    assert_equal_splitlines(out.getvalue(), expected)
+
+
+def test_rst_header_rows_unicode():
+    tbl = QTable(
+        {
+            "wave": [350, 950] * u.AA,
+            "flux": [2.3, 3.1] * u.Unit("erg / (s cm2)"),
+        }
+    )
+    out = StringIO()
+    ascii.write(tbl, out, format="rst", header_rows=["name", "unit"])
+    expected = (
+        "======== =============\n"
+        "    wave          flux\n"
+        "Angstrom erg / (cm2 s)\n"
+        "======== =============\n"
+        "   350.0           2.3\n"
+        "   950.0           3.1\n"
+        "======== =============\n"
+    )
+    assert_equal_splitlines(out.getvalue(), expected)
+
+
+def test_rst_header_rows_masked():
+    response = MaskedColumn([0.7, 1.2], mask=[False, True], unit=u.count)
+    tbl = QTable(
+        {
+            "wave": [350, 950] * u.nm,
+            "response": response,
+        }
+    )
+    out = StringIO()
+    ascii.write(tbl, out, format="rst", header_rows=["name", "unit"])
+    expected = (
+        "===== ========\n"
+        " wave response\n"
+        "   nm       ct\n"
+        "===== ========\n"
+        "350.0      0.7\n"
+        "950.0         \n"
+        "===== ========\n"
+    )
+    assert_equal_splitlines(out.getvalue(), expected)
+
+
+def test_rst_backward_compat_no_header_rows():
+    tbl = QTable(
+        {
+            "wave": [350, 950],
+            "response": [0.7, 1.2],
+        }
+    )
+    out = StringIO()
+    ascii.write(tbl, out, format="rst")
+    expected = (
+        "==== ========\n"
+        "wave response\n"
+        "==== ========\n"
+        " 350      0.7\n"
+        " 950      1.2\n"
+        "==== ========\n"
+    )
+    assert_equal_splitlines(out.getvalue(), expected)

--- a/docs/io/ascii/fixed_width_gallery.rst
+++ b/docs/io/ascii/fixed_width_gallery.rst
@@ -288,6 +288,28 @@ Fixed Width Two Line
 
 ..
   EXAMPLE START
+  Custom Header Rows with RST
+
+::
+    >>> from astropy.table import QTable
+    >>> import astropy.units as u
+    >>> from astropy.io import ascii
+    >>> tbl = QTable({"wave": [350, 950] * u.nm,
+    ...               "response": [0.7, 1.2] * u.count})
+    >>> ascii.write(tbl, format="rst", header_rows=["name", "unit"])
+    ===== ========
+     wave response
+       nm       ct
+    ===== ========
+    350.0      0.7
+    950.0      1.2
+    ===== ========
+
+..
+  EXAMPLE END
+
+..
+  EXAMPLE START
   Reading a reStructuredText Table
 
 **reStructuredText table:**


### PR DESCRIPTION
## Observed failure

`ascii.rst` currently rejects the `header_rows` keyword:

```text
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/astropy/table/connect.py", line 129, in __call__
    self.registry.write(instance, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/astropy/io/registry/core.py", line 369, in write
    return writer(data, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/astropy/io/ascii/connect.py", line 26, in io_write
    return write(table, filename, **kwargs)
  File "/usr/lib/python3/dist-packages/astropy/io/ascii/ui.py", line 856, in write
    writer = get_writer(Writer=Writer, fast_writer=fast_writer, **kwargs)
  File "/usr/lib/python3/dist-packages/astropy/io/ascii/ui.py", line 800, in get_writer
    writer = core._get_writer(Writer, fast_writer, **kwargs)
  File "/usr/lib/python3/dist-packages/astropy/io/ascii/core.py", line 1719, in _get_writer
    writer = Writer(**writer_kwargs)
TypeError: RST.__init__() got an unexpected keyword argument 'header_rows'
```

### Reproduction

```python
from astropy.table import QTable
import astropy.units as u
import sys

tbl = QTable({'wave': [350, 950] * u.nm, 'response': [0.7, 1.2] * u.count})
tbl.write(sys.stdout, format="ascii.rst", header_rows=["name", "unit"])
```

See https://github.com/agyn-sandbox/astropy/issues/118 for the full context.

## Summary

- allow `RST` to forward `header_rows` into `FixedWidth` and derive the separator line from the header row count
- extend the regression suite with header-row scenarios (units, missing units, unicode, masked values, and default behavior)
- document `header_rows` support for `ascii.rst` in the fixed-width gallery

## Testing

- `pytest astropy/io/ascii/tests/test_rst.py --maxfail=1 --disable-warnings -q`
- `pytest astropy/io/ascii/tests/test_fixedwidth.py --maxfail=1 --disable-warnings -q`
- `isort astropy/io/ascii/rst.py astropy/io/ascii/tests/test_rst.py`
- `pyupgrade --py38-plus astropy/io/ascii/rst.py astropy/io/ascii/tests/test_rst.py`
- `flake8 astropy/io/ascii/rst.py astropy/io/ascii/tests/test_rst.py`
