### PR TITLE
fix: swev-id: astropy__astropy-14539 handle FITSDiff Q VLAs

### DIFF
--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1449,7 +1449,7 @@ class TableDataDiff(_BaseDiff):
                 arrb.dtype, np.floating
             ):
                 diffs = where_not_allclose(arra, arrb, rtol=self.rtol, atol=self.atol)
-            elif "P" in col.format:
+            elif "P" in col.format or "Q" in col.format:
                 diffs = (
                     [
                         idx

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -436,6 +436,90 @@ class TestDiff(FitsTestCase):
         diff = FITSDiff(hdula, hdulb)
         assert diff.identical
 
+    def test_vla_q_identical_self(self):
+        q_data = np.array(
+            [np.array([1, 2, 3], dtype=np.int64), np.array([4], dtype=np.int64)],
+            dtype=object,
+        )
+        q_column = Column("VLA_Q", format="QJ", array=q_data)
+        fixed_column = Column("CONST", format="J", array=[10, 20])
+
+        table_hdu = BinTableHDU.from_columns([q_column, fixed_column])
+        path = self.temp("vla_q_identical.fits")
+        table_hdu.writeto(path, overwrite=True)
+
+        diff = FITSDiff(path, path)
+        assert diff.identical
+        assert "No differences found." in diff.report()
+
+    def test_vla_q_positive_diff(self):
+        base_q_data = np.array(
+            [np.array([1.0, 2.0], dtype=np.float64), np.array([3.0], dtype=np.float64)],
+            dtype=object,
+        )
+        delta_q_data = np.array(
+            [np.array([1.0, 9.0], dtype=np.float64), np.array([3.0], dtype=np.float64)],
+            dtype=object,
+        )
+
+        column_a = Column("VLA_Q", format="QE", array=base_q_data)
+        column_b = Column("VLA_Q", format="QE", array=delta_q_data)
+        fixed_column = Column("CONST", format="E", array=[5.0, 6.0])
+
+        table_a = BinTableHDU.from_columns([column_a, fixed_column])
+        table_b = BinTableHDU.from_columns([column_b, fixed_column])
+
+        path_a = self.temp("vla_q_diff_a.fits")
+        path_b = self.temp("vla_q_diff_b.fits")
+        table_a.writeto(path_a, overwrite=True)
+        table_b.writeto(path_b, overwrite=True)
+
+        diff = FITSDiff(path_a, path_b, rtol=0, atol=0)
+        assert not diff.identical
+
+        report = diff.report()
+        assert "Column VLA_Q data differs in row 0:" in report
+
+    def test_vla_p_parity(self):
+        p_data = np.array(
+            [
+                np.array([[1, 2], [3, 4]], dtype=np.int16),
+                np.array([[5, 6]], dtype=np.int16),
+            ],
+            dtype=object,
+        )
+        p_column = Column("VLA_P", format="PI(2)", array=p_data)
+        fixed_column = Column("CONST", format="J", array=[1, 2])
+
+        table_hdu = BinTableHDU.from_columns([p_column, fixed_column])
+        path = self.temp("vla_p_identical.fits")
+        table_hdu.writeto(path, overwrite=True)
+
+        diff = FITSDiff(path, path)
+        assert diff.identical
+        assert "No differences found." in diff.report()
+
+    def test_vla_q_mixed_fixed(self):
+        q_data = np.array(
+            [
+                np.array([], dtype=np.int64),
+                np.array([10, 11], dtype=np.int64),
+                np.array([12], dtype=np.int64),
+            ],
+            dtype=object,
+        )
+        q_column = Column("VLA_Q", format="QJ", array=q_data)
+        flag_column = Column("FLAG", format="L", array=[True, False, True])
+        scalar_column = Column("VALUE", format="J", array=[100, 200, 300])
+
+        table_hdu = BinTableHDU.from_columns([q_column, flag_column, scalar_column])
+        path = self.temp("vla_q_mixed.fits")
+        table_hdu.writeto(path, overwrite=True)
+
+        diff = FITSDiff(path, path)
+        assert diff.identical
+        assert "No differences found." in diff.report()
+
     def test_ignore_table_fields(self):
         c1 = Column("A", format="L", array=[True, False])
         c2 = Column("B", format="X", array=[[0], [1]])


### PR DESCRIPTION
## Issue
Closes #127.

## Observed failure
- FITSDiff skipped Q-format variable-length array (VLA) columns because the comparison logic only treated `P` descriptors as VLA data, so row-wise differences went unreported.

## Reproduction
1. Create two binary tables that include a `format="QE"` column.
2. Modify the VLA payload in one row of the second table.
3. Run `FITSDiff(file_a, file_b, rtol=0, atol=0)` — `.identical` incorrectly returns `True` and the report omits the column.

## Changes
- Update `TableDataDiff` to treat `Q`-format descriptors as VLA columns alongside `P` descriptors.
- Add regression tests covering Q-format VLAs (identical self-compare, differing payload, mixed fixed-width columns) plus a parity check for the existing P-format path.

## Testing
- `PYTHONPATH=. LD_LIBRARY_PATH='/nix/store/sbfrl6127w424l34lsq0lzryibq1226j-gcc-15.2.0/lib:/nix/store/h4qhxh7vwmxgy6w05g0xsf6r1bfi9vga-gcc-15.2.0-lib/lib:/nix/store/dvb9i3s69j29md1hpx3gpaqqds6530df-gcc-15.2.0-libgcc/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib' SETUPTOOLS_USE_DISTUTILS=stdlib .venv/bin/python -m pytest astropy/io/fits/tests/test_diff.py -k vla_q` (3 passed)
- `PYTHONPATH=. LD_LIBRARY_PATH='/nix/store/sbfrl6127w424l34lsq0lzryibq1226j-gcc-15.2.0/lib:/nix/store/h4qhxh7vwmxgy6w05g0xsf6r1bfi9vga-gcc-15.2.0-lib/lib:/nix/store/dvb9i3s69j29md1hpx3gpaqqds6530df-gcc-15.2.0-libgcc/lib:/nix/store/n5lymg0y5x6i9wipkjrsi8aczv1nr4qc-zlib-1.3.1/lib' SETUPTOOLS_USE_DISTUTILS=stdlib .venv/bin/python -m pytest astropy/io/fits/tests/test_diff.py` (52 passed)
- `SETUPTOOLS_USE_DISTUTILS=stdlib .venv/bin/tox -e codestyle -- --files astropy/io/fits/diff.py astropy/io/fits/tests/test_diff.py` (pass)